### PR TITLE
Add the Analyzer and OutputTarget interfaces, Summary class, and WinsAnalysis class

### DIFF
--- a/spreadsheet/src/Analyzers/WinsAnalysis.ts
+++ b/spreadsheet/src/Analyzers/WinsAnalysis.ts
@@ -1,0 +1,29 @@
+// Interface imports
+import { MatchData } from '../MatchData';
+import { Analyzer } from '../Summary';
+
+// Enum imports
+import { MatchResult } from '../MatchResult';
+
+export class WinsAnalysis implements Analyzer {
+  constructor(public team: string) {}
+
+  run(matches: MatchData[]): string {
+    let wins = 0;
+
+    for (let match of matches) {
+      // Game data
+      const homeTeam = match[1];
+      const awayTeam = match[2];
+      const matchResult = match[5];
+    
+      // Calculate the total wins
+      if (homeTeam == 'Man United' && matchResult == MatchResult.HomeWin) {
+        wins++;
+      } else if (awayTeam == 'Man United' && matchResult == MatchResult.AwayWin) {
+        wins++;
+      }
+  }
+
+  return `Team ${this.team} won ${wins} games`;
+}

--- a/spreadsheet/src/MatchData.ts
+++ b/spreadsheet/src/MatchData.ts
@@ -1,0 +1,4 @@
+// Enum imports
+import { MatchResult } from './MatchResult';
+
+export type MatchData = [Date, string, string, number, number, MatchResult];

--- a/spreadsheet/src/MatchReader.ts
+++ b/spreadsheet/src/MatchReader.ts
@@ -4,12 +4,12 @@ import { dateStringtToDate } from './utils';
 // Enum imports
 import { MatchResult } from './MatchResult';
 
-// Tuples
-type MatchData = [Date, string, string, number, number, MatchResult];
+// Tuple imports
+import { MatchData } from './MatchData';
 
 interface DataReader {
-  read(): void
-  data: string[][]
+  read(): void;
+  data: string[][];
 }
 
 export class MatchReader {
@@ -27,8 +27,9 @@ export class MatchReader {
           row[2], // Away team
           parseInt(row[3]), // Home goals scored
           parseInt(row[4]), // Away goals scored
-          row[5] as MatchResult // Match result
-        ]
-      });
+          row[5] as MatchResult, // Match result
+        ];
+      }
+    );
   }
 }

--- a/spreadsheet/src/Summary.ts
+++ b/spreadsheet/src/Summary.ts
@@ -1,0 +1,16 @@
+// Tuple imports
+import { MatchData } from './MatchData';
+
+export interface Analyzer {
+  run(matches: MatchData[]): string;
+}
+
+export interface OutputTarget {
+  print(report: string): void;
+}
+
+export class Summary {
+  constructor(public analyzer: Analyzer, public outputTarget: OutputTarget) {}
+
+  buildAndPrintReport(matchData: MatchData[]) {}
+}

--- a/spreadsheet/src/Summary.ts
+++ b/spreadsheet/src/Summary.ts
@@ -12,5 +12,7 @@ export interface OutputTarget {
 export class Summary {
   constructor(public analyzer: Analyzer, public outputTarget: OutputTarget) {}
 
-  buildAndPrintReport(matchData: MatchData[]) {}
+  buildAndPrintReport(matchData: MatchData[]) {
+    
+  }
 }


### PR DESCRIPTION
In this pull request, I made the following changes to the spreadsheet project:
* Refactored the app so that the index.ts file no longer was in charge of calculating the total wins for the team. 
* Split out the wins analysis logic into the `WinsAnalysis` class
* Added type interfaces for `Analyzer` and `OutputTarget` for the arguments for the `Summary` class constructor